### PR TITLE
Add token blacklist for logout

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import User, { IUserToken } from '../models/userModel';
 import { generateTokenFromUser } from '../utils/tokenUtil';
+import { addTokenToBlacklist } from '../utils/tokenBlacklist';
 
 export const getUser = async (req: Request, res: Response, next: NextFunction) => {
 	try {
@@ -81,9 +82,9 @@ export const refreshUserToken = async (req: Request, res: Response, next: NextFu
 };
 
 export const changePassword = async (req: Request, res: Response, next: NextFunction) => {
-	try {
-		const { password } = req.body;
-		const u = req.user as IUserToken;
+        try {
+                const { password } = req.body;
+                const u = req.user as IUserToken;
 
 		const user = await User.findById(u.id);
 		if (!user) {
@@ -93,9 +94,15 @@ export const changePassword = async (req: Request, res: Response, next: NextFunc
 
 		user.password = password;
 
-		await user.save();
-		res.json({ message: 'Password updated' });
-	} catch (error) {
-		next(error);
-	}
+                await user.save();
+                res.json({ message: 'Password updated' });
+        } catch (error) {
+                next(error);
+        }
+};
+
+export const logoutUser = async (req: Request, res: Response, _next: NextFunction) => {
+        const u = req.user as IUserToken;
+        addTokenToBlacklist(u);
+        res.json({ message: 'Logout successful' });
 };

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { IUserToken } from '../models/userModel';
+import { isTokenBlacklisted } from '../utils/tokenBlacklist';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'SECRET_FOR_JWT_IS_SECRET';
 
@@ -11,25 +12,30 @@ export const authMiddleware = async (req: Request, res: Response, next: NextFunc
 		return;
 	}
 
-	const decoded = jwt.verify(token, JWT_SECRET) as IUserToken;
+        const decoded = jwt.verify(token, JWT_SECRET) as IUserToken;
 
-	const userId = decoded.id;
+        const userId = decoded.id;
 
-	if (!userId) {
-		res.status(401).json({ message: 'Unauthorized' });
-		return;
-	}
+        if (!userId) {
+                res.status(401).json({ message: 'Unauthorized' });
+                return;
+        }
 
-	const user: IUserToken = {
-		id: userId,
-		iat: decoded.iat,
-		exp: decoded.exp,
-		name: decoded.name,
-		email: decoded.email,
-	};
+        const user: IUserToken = {
+                id: userId,
+                iat: decoded.iat,
+                exp: decoded.exp,
+                name: decoded.name,
+                email: decoded.email,
+        };
 
-	req.user = user as IUserToken;
-	return next();
+        if (isTokenBlacklisted(user)) {
+                res.status(401).json({ message: 'Unauthorized' });
+                return;
+        }
+
+        req.user = user as IUserToken;
+        return next();
 };
 
 export const authMiddlewarePassable = async (req: Request, _res: Response, next: NextFunction) => {
@@ -38,21 +44,23 @@ export const authMiddlewarePassable = async (req: Request, _res: Response, next:
 		return next();
 	}
 
-	const decoded = jwt.verify(token, JWT_SECRET) as IUserToken;
+        const decoded = jwt.verify(token, JWT_SECRET) as IUserToken;
 
-	if (decoded && decoded?.id) {
-		const userId = decoded.id;
+        if (decoded && decoded?.id) {
+                const userId = decoded.id;
 
-		const user: IUserToken = {
-			id: userId,
-			iat: decoded.iat,
-			exp: decoded.exp,
-			name: decoded.name,
-			email: decoded.email,
-		};
+                const user: IUserToken = {
+                        id: userId,
+                        iat: decoded.iat,
+                        exp: decoded.exp,
+                        name: decoded.name,
+                        email: decoded.email,
+                };
 
-		req.user = user as IUserToken;
-	}
+                if (!isTokenBlacklisted(user)) {
+                        req.user = user as IUserToken;
+                }
+        }
 
 	return next();
 };

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { getUser, changePassword, createUser, authUser, refreshUserToken } from '../controllers/userController';
+import { getUser, changePassword, createUser, authUser, refreshUserToken, logoutUser } from '../controllers/userController';
 import { authMiddleware } from '../middlewares/authMiddleware';
 
 const userRouter = express.Router();
@@ -58,5 +58,15 @@ userRouter.get('/refresh-token', authMiddleware, refreshUserToken);
  * @apiBody {String} password The password of the user
  */
 userRouter.put('/', authMiddleware, changePassword);
+
+/**
+ * @api {post} /user/logout Logout User
+ * @apiName LogoutUser
+ * @apiGroup User
+ * @apiPermission User
+ *
+ * @apiHeader {String} Authorization Bearer token
+ */
+userRouter.post('/logout', authMiddleware, logoutUser);
 
 export default userRouter;

--- a/src/utils/tokenBlacklist.ts
+++ b/src/utils/tokenBlacklist.ts
@@ -1,0 +1,35 @@
+// Token blacklist management
+
+import { IUserToken } from '../models/userModel';
+
+interface TokenBlacklistMap {
+        [key: string]: number;
+}
+
+const tokenBlacklist: TokenBlacklistMap = {};
+
+export const addTokenToBlacklist = (token: IUserToken) => {
+        if (!token.id || token.iat === undefined || token.exp === undefined) {
+                return;
+        }
+        const key = `${token.id}-${token.iat}`;
+        tokenBlacklist[key] = token.exp * 1000; // store expiration in ms
+};
+
+export const isTokenBlacklisted = (token: IUserToken): boolean => {
+        if (!token.id || token.iat === undefined) {
+                return false;
+        }
+        const key = `${token.id}-${token.iat}`;
+        const expiry = tokenBlacklist[key];
+        if (!expiry) {
+                return false;
+        }
+        if (expiry <= Date.now()) {
+                delete tokenBlacklist[key];
+                return false;
+        }
+        return true;
+};
+
+export default tokenBlacklist;


### PR DESCRIPTION
## Summary
- create in-memory token blacklist with expiry
- deny requests with blacklisted token
- add logout controller and route

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68585d2415d48321b1310c312119b3ff